### PR TITLE
add utilities to create julia compatible data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+examples/data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PyOnda
-Python tools to handle Onda formatted data
+Python tools to handle [Onda](https://github.com/beacon-biosignals/Onda.jl/tree/main) formatted data
 
 ## Setup
 The packaging uses hatch.

--- a/examples/generate_data.py
+++ b/examples/generate_data.py
@@ -1,0 +1,68 @@
+from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, timespan_namedtuple
+from pyonda.utils.processing import convert_python_uuid_to_uuid_bytestring
+
+from pyonda.save_arrow import save_table_to_arrow_file
+from pyonda.save_lpcm import save_array_to_lpcm_file
+
+from pathlib import Path
+
+import pyarrow as pa
+import numpy as np
+import uuid
+
+"""
+This is a script to generate a mock Arrow table with the Annotations Schema
+as well as a mock lpcm file (saving a numpy array)
+
+The goal is to check that the data is as expected when loaded with Julia
+
+TODO : add real test files to check this automatically
+"""
+
+original_record_uuid = uuid.uuid4()
+print("Original record UUID:", original_record_uuid)
+
+original_annot_uuids = [uuid.uuid4() for i in range(3)]
+print("Original annotations UUIDs:", original_annot_uuids)
+
+# Reverse bytes for UUIDs
+rows = (
+    [convert_python_uuid_to_uuid_bytestring(original_record_uuid)] * 3, 
+    [convert_python_uuid_to_uuid_bytestring(x) for x in original_annot_uuids], 
+    [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
+)
+table = pa.Table.from_pydict(dict(zip(ONDA_ANNOTATIONS_SCHEMA.names, rows)), schema=ONDA_ANNOTATIONS_SCHEMA)
+
+data_folder = Path(__file__).parent / 'data'
+data_folder.mkdir(exist_ok=True)
+
+save_table_to_arrow_file(table, ONDA_ANNOTATIONS_SCHEMA, data_folder / "table_test1.arrow")
+
+# TODO : load saved table with Julia to check match
+
+# Generate Random (10, 5) array where each line sums to 1 (probability mock)
+proba_array = np.random.dirichlet(np.ones(5), size=10).astype(np.float32)
+print("Mock density array: \n", proba_array)
+
+save_array_to_lpcm_file(proba_array, data_folder / "array_test.lpcm")
+
+""" 
+# Julia code (adapt paths): 
+
+using Arrow, TimeSpans, UUIDs, DataFrames, Dates, Onda
+
+path_to_table = '/PyOnda/examples/data/table_test1.arrow'
+table = Arrow.Table(path_to_table)
+DataFrame(table)
+
+path_to_array = '/PyOnda/examples/data/array_test.lpcm'
+signal = SignalV2(;sensor_type="test", channels=["wake", "n1", "n2", "n3", "rem"], 
+                   sample_unit="proba", sample_resolution_in_unit=1.0, sample_offset_in_unit=0.0, 
+                   sample_type=Float32, sample_rate=1/30, recording=UUID(1), 
+                   file_path=path_to_array, 
+                   file_format="lpcm", span=TimeSpan(Nanosecond(0), Nanosecond(300000000000)), 
+                   sensor_label="test")
+Onda.load(signal)
+
+# Onda.load shows a (5, 10) signal with channels going top down (1st row = wake)
+"""

--- a/examples/generate_data.py
+++ b/examples/generate_data.py
@@ -1,4 +1,4 @@
-from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, timespan_namedtuple
+from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, ONDA_SIGNALS_SCHEMA, timespan_namedtuple
 from pyonda.utils.processing import convert_python_uuid_to_uuid_bytestring
 
 from pyonda.save_arrow import save_table_to_arrow_file
@@ -9,6 +9,7 @@ from pathlib import Path
 import pyarrow as pa
 import numpy as np
 import uuid
+import os
 
 """
 This is a script to generate a mock Arrow table with the Annotations Schema
@@ -26,17 +27,18 @@ original_annot_uuids = [uuid.uuid4() for i in range(3)]
 print("Original annotations UUIDs:", original_annot_uuids)
 
 # Reverse bytes for UUIDs
-rows = (
-    [convert_python_uuid_to_uuid_bytestring(original_record_uuid)] * 3, 
-    [convert_python_uuid_to_uuid_bytestring(x) for x in original_annot_uuids], 
-    [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
-)
-table = pa.Table.from_pydict(dict(zip(ONDA_ANNOTATIONS_SCHEMA.names, rows)), schema=ONDA_ANNOTATIONS_SCHEMA)
+rows = {
+    'recording': [convert_python_uuid_to_uuid_bytestring(original_record_uuid)] * 3, 
+    'id': [convert_python_uuid_to_uuid_bytestring(x) for x in original_annot_uuids], 
+    'span': [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
+}
+table = pa.Table.from_pydict(rows, schema=ONDA_ANNOTATIONS_SCHEMA)
 
-data_folder = Path(__file__).parent / 'data'
+data_folder = Path(__file__).parent.resolve() / 'data'
 data_folder.mkdir(exist_ok=True)
+print(f"Saving to {data_folder}")
 
-save_table_to_arrow_file(table, ONDA_ANNOTATIONS_SCHEMA, data_folder / "table_test1.arrow")
+save_table_to_arrow_file(table, ONDA_ANNOTATIONS_SCHEMA, data_folder / "table_test.annotations.arrow")
 
 # TODO : load saved table with Julia to check match
 
@@ -46,23 +48,23 @@ print("Mock density array: \n", proba_array)
 
 save_array_to_lpcm_file(proba_array, data_folder / "array_test.lpcm")
 
-""" 
-# Julia code (adapt paths): 
-
-using Arrow, TimeSpans, UUIDs, DataFrames, Dates, Onda
-
-path_to_table = '/PyOnda/examples/data/table_test1.arrow'
-table = Arrow.Table(path_to_table)
-DataFrame(table)
-
-path_to_array = '/PyOnda/examples/data/array_test.lpcm'
-signal = SignalV2(;sensor_type="test", channels=["wake", "n1", "n2", "n3", "rem"], 
-                   sample_unit="proba", sample_resolution_in_unit=1.0, sample_offset_in_unit=0.0, 
-                   sample_type=Float32, sample_rate=1/30, recording=UUID(1), 
-                   file_path=path_to_array, 
-                   file_format="lpcm", span=TimeSpan(Nanosecond(0), Nanosecond(300000000000)), 
-                   sensor_label="test")
-Onda.load(signal)
-
-# Onda.load shows a (5, 10) signal with channels going top down (1st row = wake)
-"""
+# Save signal table
+original_signal_uuid = uuid.uuid4()
+print(str(data_folder / "array_test.lpcm"))
+rows = {
+    'recording': [convert_python_uuid_to_uuid_bytestring(original_record_uuid)], 
+    'id': [convert_python_uuid_to_uuid_bytestring(original_signal_uuid)], 
+    'file_path': [str(data_folder / "array_test.lpcm")],
+    'file_format': ["lpcm"],
+    'span': [timespan_namedtuple(start=0, stop=int(300*(1e9)))],
+    'sensor_type':["segmentation_model"],
+    'sensor_label': ["hypnodensity"],
+    'channels': [["wake", "n1", "n2", "n3", "rem"]],
+    'sample_unit': ["probability"],
+    'sample_resolution_in_unit': [1],
+    'sample_offset_in_unit': [0],
+    'sample_type': ['float32'],
+    'sample_rate': [1/30]
+}
+table = pa.Table.from_pydict(rows, schema=ONDA_SIGNALS_SCHEMA)
+save_table_to_arrow_file(table, ONDA_SIGNALS_SCHEMA, data_folder / "table_test.signal.arrow")

--- a/examples/read_generated_data.jl
+++ b/examples/read_generated_data.jl
@@ -1,0 +1,30 @@
+# Julia code (adapt paths): 
+using Onda, Legolas, Arrow, TimeSpans, DataFrames, Dates, UUIDs
+using Legolas: @schema, @version
+
+# ---- Annotation table -----
+# Will contain annotations events for all inference records
+# Load table (not validated)
+path_to_annotations = joinpath(pwd(), "data/table_test.annotations.arrow")
+annotation_table = Arrow.Table(path_to_annotations)
+
+# Construct schema compliant Table
+path_to_annotations_validated = joinpath(pwd(), "data/table_test.annotations.validated.arrow")
+annotations = [AnnotationV1(r) for r in Tables.rows(annotation_table)]
+Legolas.write(path_to_annotations_validated, annotations, AnnotationV1SchemaVersion())
+
+# Load table with Legolas.read
+annotation_df = DataFrame(Legolas.read(path_to_annotations_validated))
+
+# ---- Signal table -----
+# Will contain SignalV2 rows for all records pointing to inference files
+# Load signal table (not validated)
+path_to_signal = joinpath(pwd(), "data/table_test.signal.arrow")
+signal_table = Arrow.Table(path_to_signal)
+signals = [SignalV2(r) for r in Tables.rows(signal_table)]
+
+path_to_signals_validated = joinpath(pwd(), "data/table_test.signal.validated.arrow")
+Legolas.write(path_to_signals_validated, signals, SignalV2SchemaVersion())
+
+signal_df = DataFrame(Legolas.read(path_to_signals_validated))
+Onda.load(signal_df[1,:]) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "pytest",
   "moto==4.1.15"
 ]
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyonda"
-version = "0.0.0"
+version = "0.1.0"
 description = 'Python tools to handle Onda formatted data'
 readme = "README.md"
 requires-python = ">=3.8, <3.10"

--- a/src/pyonda/load_lpcm.py
+++ b/src/pyonda/load_lpcm.py
@@ -70,7 +70,6 @@ def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F"):
     order : str
         C or F, use F to read files from Julia, use C to save files for Julia
 
-
     Returns
     -------
     data: ndarray
@@ -80,7 +79,7 @@ def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F"):
     return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)
 
 
-def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels):
+def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels, order="F"):
     """Decompress lpcm zst and load file content as a numpy array with correct data type and shape
 
     Parameters
@@ -91,6 +90,8 @@ def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels):
         data sample type (passed to dtype argument in numpy)
     n_channels : int
         number of channels used to reshape data
+    order : str
+        C or F, use F to read files from Julia, use C to save files for Julia
 
     Returns
     -------
@@ -98,10 +99,10 @@ def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels):
         numpy array with lpcm file content 
     """
     file_buf = decompress_zstandard_file_to_stream(path_to_file)
-    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels)
+    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)
 
 
-def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels):
+def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels, order="F"):
     """Decompress lpcm zst from s3 and load file content as a numpy array with correct data type and shape
 
     Parameters
@@ -112,6 +113,8 @@ def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels):
         data sample type (passed to dtype argument in numpy)
     n_channels : int
         number of channels used to reshape data
+    order : str
+        C or F, use F to read files from Julia, use C to save files for Julia
 
     Returns
     -------
@@ -120,4 +123,4 @@ def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels):
     """
     file_buf = download_s3_fileobj(file_url)
     file_buf = decompress_zstandard_stream_to_stream(file_buf)
-    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels)
+    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)

--- a/src/pyonda/load_lpcm.py
+++ b/src/pyonda/load_lpcm.py
@@ -5,7 +5,7 @@ from pyonda.utils.s3_download import download_s3_fileobj
 from pyonda.utils.decompression import decompress_zstandard_file_to_stream, decompress_zstandard_stream_to_stream
 
 
-def load_array_from_lpcm_file_buffer(buffer, dtype, n_channels):
+def load_array_from_lpcm_file_buffer(buffer, dtype, n_channels, order="F"):
     """Load lpcm file content as a numpy array with correct data type and shape
 
     Parameters
@@ -16,6 +16,8 @@ def load_array_from_lpcm_file_buffer(buffer, dtype, n_channels):
         data sample type (passed to dtype argument in numpy)
     n_channels : int
         number of channels used to reshape data
+    order : str
+        C or F, use F to read files from Julia, use C to save files for Julia
 
     Returns
     -------
@@ -26,10 +28,10 @@ def load_array_from_lpcm_file_buffer(buffer, dtype, n_channels):
     full_length = len(data)
     if full_length % n_channels != 0:
         raise ValueError(f'n_channels ({n_channels}) not a multiple of array length ({full_length})')
-    return data.reshape(n_channels,-1, order="F")
+    return data.reshape(n_channels,-1, order=order)
 
 
-def load_array_from_lpcm_file(path_to_file, dtype, n_channels):
+def load_array_from_lpcm_file(path_to_file, dtype, n_channels, order="F"):
     """Load lpcm file content as a numpy array with correct data type and shape
 
     Parameters
@@ -40,6 +42,9 @@ def load_array_from_lpcm_file(path_to_file, dtype, n_channels):
         data sample type (passed to dtype argument in numpy.memmap)
     n_channels : int
         number of channels used to reshape data
+    order : str
+        C or F, use F to read files from Julia, use C to save files for Julia
+
 
     Returns
     -------
@@ -48,10 +53,10 @@ def load_array_from_lpcm_file(path_to_file, dtype, n_channels):
     """
     with open(path_to_file, "rb") as fh:
         buffer = io.BytesIO(fh.read())
-    return load_array_from_lpcm_file_buffer(buffer, dtype, n_channels)
+    return load_array_from_lpcm_file_buffer(buffer, dtype, n_channels, order)
 
 
-def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels):
+def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F"):
     """Load lpcm file content from S3 as a numpy array with correct data type and shape
 
     Parameters
@@ -62,6 +67,9 @@ def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels):
         data sample type (passed to dtype argument in numpy)
     n_channels : int
         number of channels used to reshape data
+    order : str
+        C or F, use F to read files from Julia, use C to save files for Julia
+
 
     Returns
     -------
@@ -69,7 +77,7 @@ def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels):
         numpy array with lpcm file content 
     """
     file_buf = download_s3_fileobj(file_url)
-    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels)
+    return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)
 
 
 def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels):

--- a/src/pyonda/save_arrow.py
+++ b/src/pyonda/save_arrow.py
@@ -43,7 +43,8 @@ def save_table_to_s3(table, schema, bucket, key):
     """
     temp_dir = tempfile.TemporaryDirectory() 
     temp_file_path = Path(temp_dir.name) / "table_to_upload.arrow"
-    save_table_to_arrow_file(table, schema, temp_file_path)
-    upload_status = upload_file_to_s3(temp_file_path, bucket, key)
-    temp_dir.cleanup()
-    return upload_status
+    try:
+        save_table_to_arrow_file(table, schema, temp_file_path)
+        upload_file_to_s3(temp_file_path, bucket, key)
+    finally:
+        temp_dir.cleanup()

--- a/src/pyonda/save_arrow.py
+++ b/src/pyonda/save_arrow.py
@@ -1,0 +1,49 @@
+import pyarrow as pa
+import tempfile
+
+from pyonda.utils.s3_upload import upload_file_to_s3
+from pathlib import Path
+
+
+def save_table_to_arrow_file(output_path, table, schema):
+    """Sable pyarrow Table to output_path
+
+    Parameters
+    ----------
+    output_path : str or Path
+        output file path
+    table : pyarrow.lib.Table
+        table to save
+    schema : pyarrow.lib.Schema
+        schema of the table to save
+    """
+    with pa.OSFile(str(output_path), 'wb') as sink:
+        with pa.ipc.new_file(sink, schema=schema) as writer:
+            writer.write(table)
+
+
+def save_table_to_s3(table, schema, bucket, key):
+    """Save table in a temp dir and upload it to s3
+
+    Parameters
+    ----------
+    table : pyarrow.lib.Table
+        table to save
+    schema : pyarrow.lib.Schema
+        schema of the table to save
+    bucket : str
+        destination bucket name
+    key : str
+        destination file key
+
+    Returns
+    -------
+    upload_status: bool
+        False if ClientError is catched during upload
+    """
+    temp_dir = tempfile.TemporaryDirectory() 
+    temp_file_path = Path(temp_dir.name) / "table_to_upload.arrow"
+    save_table_to_arrow_file(temp_file_path, table, schema)
+    upload_status = upload_file_to_s3(temp_file_path, bucket, key)
+    temp_dir.cleanup()
+    return upload_status

--- a/src/pyonda/save_arrow.py
+++ b/src/pyonda/save_arrow.py
@@ -5,17 +5,17 @@ from pyonda.utils.s3_upload import upload_file_to_s3
 from pathlib import Path
 
 
-def save_table_to_arrow_file(output_path, table, schema):
+def save_table_to_arrow_file(table, schema, output_path):
     """Sable pyarrow Table to output_path
 
     Parameters
     ----------
-    output_path : str or Path
-        output file path
     table : pyarrow.lib.Table
         table to save
     schema : pyarrow.lib.Schema
         schema of the table to save
+    output_path : str or Path
+        output file path
     """
     with pa.OSFile(str(output_path), 'wb') as sink:
         with pa.ipc.new_file(sink, schema=schema) as writer:
@@ -43,7 +43,7 @@ def save_table_to_s3(table, schema, bucket, key):
     """
     temp_dir = tempfile.TemporaryDirectory() 
     temp_file_path = Path(temp_dir.name) / "table_to_upload.arrow"
-    save_table_to_arrow_file(temp_file_path, table, schema)
+    save_table_to_arrow_file(table, schema, temp_file_path)
     upload_status = upload_file_to_s3(temp_file_path, bucket, key)
     temp_dir.cleanup()
     return upload_status

--- a/src/pyonda/save_lpcm.py
+++ b/src/pyonda/save_lpcm.py
@@ -47,9 +47,11 @@ def save_array_to_lpcm_zst_file(array, output_path):
     temp_dir = tempfile.TemporaryDirectory()
 
     lpcm_path = Path(temp_dir.name, output_path.stem)
-    save_array_to_lpcm_file(array, lpcm_path)
-    compress_file_to_zst(lpcm_path, output_path.parent)
-    temp_dir.cleanup()
+    try:
+        save_array_to_lpcm_file(array, lpcm_path)
+        compress_file_to_zst(lpcm_path, output_path.parent)
+    finally:
+        temp_dir.cleanup()
 
 
 def save_array_to_lpcm_file_in_s3(array, bucket, key):
@@ -71,11 +73,11 @@ def save_array_to_lpcm_file_in_s3(array, bucket, key):
     """
     temp_dir = tempfile.TemporaryDirectory() 
     temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
-    save_array_to_lpcm_file(array, temp_file_path)
-
-    upload_status = upload_file_to_s3(temp_file_path, bucket, key)
-    temp_dir.cleanup()
-    return upload_status
+    try:
+        save_array_to_lpcm_file(array, temp_file_path)
+        upload_status = upload_file_to_s3(temp_file_path, bucket, key)
+    finally:
+        temp_dir.cleanup()
 
 
 def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
@@ -99,10 +101,11 @@ def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
     """
     temp_dir = tempfile.TemporaryDirectory() 
     temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
-    save_array_to_lpcm_file(array, temp_file_path)
-    compress_file_to_zst(temp_file_path, Path(temp_dir.name))
+    try:
+        save_array_to_lpcm_file(array, temp_file_path)
+        compress_file_to_zst(temp_file_path, Path(temp_dir.name))
 
-    compressed_file_path = Path(temp_dir.name) / 'array_to_upload.lpcm.zst'
-    upload_status = upload_file_to_s3(compressed_file_path, bucket, key)
-    temp_dir.cleanup()
-    return upload_status
+        compressed_file_path = Path(temp_dir.name) / 'array_to_upload.lpcm.zst'
+        upload_file_to_s3(compressed_file_path, bucket, key)
+    finally:
+        temp_dir.cleanup()

--- a/src/pyonda/save_lpcm.py
+++ b/src/pyonda/save_lpcm.py
@@ -1,0 +1,53 @@
+import numpy as np
+import tempfile
+from pathlib import Path
+from pyonda.utils.s3_upload import upload_file_to_s3
+
+
+def save_array_to_lpcm_file(array, output_path):
+    """Save numpy array to .lpcm binary file
+
+    Parameters
+    ----------
+    array : ndarray
+        input numpy array to be saved
+    output_path : str or Path
+        output file path
+    """
+    output_path = str(output_path)
+    if output_path[-5:]!=".lpcm":
+        raise ValueError(f"output path should have .lpcm extension (you have {output_path[:-5]})")
+
+    holder = np.memmap(
+        output_path, 
+        dtype=array.dtype, 
+        mode='w+', 
+        shape=array.shape, 
+        order='C'
+    )
+    holder[:] = array
+
+
+def save_array_to_lpcm_file_in_s3(array, bucket, key):
+    """Save a numpy array in a temp dir as a .lpcm and upload it to s3
+
+    Parameters
+    ----------
+    array : ndarray
+        input numpy array to be saved
+    bucket : str
+        destination bucket name
+    key : str
+        destination file key
+
+    Returns
+    -------
+    upload_status: bool
+        False if ClientError is catched during upload
+    """
+    temp_dir = tempfile.TemporaryDirectory() 
+    temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
+    save_array_to_lpcm_file(array, temp_file_path)
+    upload_status = upload_file_to_s3(temp_file_path, bucket, key)
+    temp_dir.cleanup()
+    return upload_status

--- a/src/pyonda/save_lpcm.py
+++ b/src/pyonda/save_lpcm.py
@@ -1,7 +1,9 @@
 import numpy as np
 import tempfile
+import os
 from pathlib import Path
 from pyonda.utils.s3_upload import upload_file_to_s3
+from pyonda.utils.compression import compress_file_to_zst
 
 
 def save_array_to_lpcm_file(array, output_path):
@@ -28,6 +30,28 @@ def save_array_to_lpcm_file(array, output_path):
     holder[:] = array
 
 
+def save_array_to_lpcm_zst_file(array, output_path):
+    """Save numpy array to .lpcm.zst compressed binary file
+
+    Parameters
+    ----------
+    array : ndarray
+        input numpy array to be saved
+    output_path : str or Path
+        output file path
+    """
+    if str(output_path)[-9:]!=".lpcm.zst":
+        raise ValueError(f"output path should have .lpcm.zst extension (you have {str(output_path)[:-9]})")
+    
+    output_path = Path(output_path)
+    temp_dir = tempfile.TemporaryDirectory()
+
+    lpcm_path = Path(temp_dir.name, output_path.stem)
+    save_array_to_lpcm_file(array, lpcm_path)
+    compress_file_to_zst(lpcm_path, output_path.parent)
+    temp_dir.cleanup()
+
+
 def save_array_to_lpcm_file_in_s3(array, bucket, key):
     """Save a numpy array in a temp dir as a .lpcm and upload it to s3
 
@@ -48,6 +72,37 @@ def save_array_to_lpcm_file_in_s3(array, bucket, key):
     temp_dir = tempfile.TemporaryDirectory() 
     temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
     save_array_to_lpcm_file(array, temp_file_path)
+
     upload_status = upload_file_to_s3(temp_file_path, bucket, key)
+    temp_dir.cleanup()
+    return upload_status
+
+
+def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
+    """Save a numpy array in a temp dir as a .lpcm and upload it to s3
+
+    Parameters
+    ----------
+    array : ndarray
+        input numpy array to be saved
+    bucket : str
+        destination bucket name
+    key : str
+        destination file key
+    compress : bool, default=False
+        if true, compress file to .zst 
+
+    Returns
+    -------
+    upload_status: bool
+        False if ClientError is catched during upload
+    """
+    temp_dir = tempfile.TemporaryDirectory() 
+    temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
+    save_array_to_lpcm_file(array, temp_file_path)
+    compress_file_to_zst(temp_file_path, Path(temp_dir.name))
+
+    compressed_file_path = Path(temp_dir.name) / 'array_to_upload.lpcm.zst'
+    upload_status = upload_file_to_s3(compressed_file_path, bucket, key)
     temp_dir.cleanup()
     return upload_status

--- a/src/pyonda/utils/compression.py
+++ b/src/pyonda/utils/compression.py
@@ -1,0 +1,23 @@
+import zstandard
+from pathlib import Path
+
+
+def compress_file_to_zst(input_file, output_dir):
+    """Compress file to .zst
+    https://python-zstandard.readthedocs.io/en/latest/compressor.html
+
+    Parameters
+    ----------
+    input_file : str or Path
+        path to original file
+    output_file : str or Path
+        path of output .zst file
+    """
+    input_file = Path(input_file)
+    output_file = Path(output_dir) / f"{input_file.name}.zst"
+    print(input_file, output_file)
+
+    with open(input_file, 'rb') as f:
+        c = zstandard.ZstdCompressor()
+        with open(output_file, 'wb') as destination:
+            c.copy_stream(f, destination)

--- a/src/pyonda/utils/s3_upload.py
+++ b/src/pyonda/utils/s3_upload.py
@@ -1,7 +1,4 @@
 import boto3 
-import logging
-
-from botocore.exceptions import ClientError
 
 
 def upload_file_to_s3(input_path, bucket, key):
@@ -18,9 +15,4 @@ def upload_file_to_s3(input_path, bucket, key):
         destination key
     """
     client = boto3.client("s3")
-    try:
-        response = client.upload_file(str(input_path), bucket, key)
-    except ClientError as e:
-        logging.error(e)
-        return False
-    return True
+    _ = client.upload_file(str(input_path), bucket, key)

--- a/src/pyonda/utils/s3_upload.py
+++ b/src/pyonda/utils/s3_upload.py
@@ -1,0 +1,26 @@
+import boto3 
+import logging
+
+from botocore.exceptions import ClientError
+
+
+def upload_file_to_s3(input_path, bucket, key):
+    """Upload a file to S3
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html
+
+    Parameters
+    ----------
+    input_path : str or Path
+        path to file to be uploaded
+    bucket : str
+        destination bucket name
+    key : str
+        destination key
+    """
+    client = boto3.client("s3")
+    try:
+        response = client.upload_file(str(input_path), bucket, key)
+    except ClientError as e:
+        logging.error(e)
+        return False
+    return True

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -1,0 +1,78 @@
+import pyarrow as pa
+import warnings
+from collections import namedtuple
+
+
+def timespan_namedtuple(start, stop):
+    """https://github.com/beacon-biosignals/TimeSpans.jl
+    Make sure to provide nanosecond values for start and stop
+
+    Parameters
+    ----------
+    start: int
+        start of span (in nanoseconds)
+    stop: int
+        stop of span (in nanoseconds)
+
+    Returns
+    -------
+    timespan : namedtuple
+        namedtuple to mimic TimeSpan struct
+
+    Examples
+    --------
+    >>> TimeSpan = timespan_namedtuple()
+    >>> ts = TimeSpan(start=1 * 1e9, stop=3 * 1e9)
+    >>> ts
+    TimeSpan(start=1000000000.0, stop=3000000000.0)
+    >>> ts.start
+    1000000000.0
+    """
+    if stop <= start:
+        raise ValueError('start should be < stop')
+
+    if not isinstance(stop, int) or not isinstance(start, int):
+        raise ValueError('start and stop should be integers (nanosecond values)')
+
+    if start != 0 and start < 1e9:
+        warnings.warn('You have 0 < start < 1s, check that you put the value in nanoseconds')
+
+    timespan = namedtuple('TimeSpan', ['start', 'stop'])
+    return timespan(start=start, stop=stop)
+
+
+def get_onda_annotations_schema():
+    """https://github.com/beacon-biosignals/Onda.jl/blob/main/src/annotations.jl
+    Return the equivalent of onda.annotation@1 schema, with metadata pointing 
+    to Julia types, to make the arrow table readable with Julia
+
+    Returns
+    -------
+    schema : pyarrow.schema
+        pyarrow version of the annotations schema, readable by Julia
+
+    Examples
+    --------
+    >>> from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtuple
+    >>> from pyonda.utils.processing import convert_python_uuid
+    >>> import pyarrow as pa
+    >>> import uuid
+    >>> schema = get_onda_annotations_schema()
+    >>> record_uuid = convert_python_uuid(uuid.uuid4())
+    >>> rows = (
+    >>>    [record_uuid] * 3, 
+    >>>    [convert_python_uuid(uuid.uuid4()) for i in range(3)], 
+    >>>    [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
+    >>> )
+    >>> table = pa.Table.from_pydict(dict(zip(schema.names, rows)), schema=schema)
+    """
+    return pa.schema(
+        [
+            pa.field('recording', pa.binary(16), 
+                     metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
+            pa.field('id', pa.binary(16), 
+                     metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
+            pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+                     metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}),
+        ]
+    )

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -57,10 +57,7 @@ ONDA_ANNOTATIONS_SCHEMA = pa.schema(
             nullable=False,
             metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
         ),
-    ],
-    metadata = {
-        "legolas_schema_qualified" : "clean-sleep.signal@1>datastore.signal@1>onda.signal@2>onda.samples-info@2"
-    }
+    ]
 )
 
 # https://github.com/beacon-biosignals/Onda.jl/blob/main/src/signals.jl

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -41,41 +41,27 @@ def timespan_namedtuple(start, stop):
     return timespan(start=start, stop=stop)
 
 
-def get_onda_annotations_schema():
-    """https://github.com/beacon-biosignals/Onda.jl/blob/main/src/annotations.jl
-    Return the equivalent of onda.annotation@1 schema, with metadata pointing 
-    to Julia types, to make the arrow table readable with Julia
-
-    Returns
-    -------
-    schema : pyarrow.schema
-        pyarrow version of the annotations schema, readable by Julia
-
-    Examples
-    --------
-    >>> from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtuple
-    >>> from pyonda.utils.processing import convert_python_uuid_to_uuid_bytestring
-    >>> import pyarrow as pa
-    >>> import uuid
-    >>> schema = get_onda_annotations_schema()
-    >>> record_uuid = convert_python_uuid_to_uuid_bytestring(uuid.uuid4())
-    >>> rows = (
-    >>>    [record_uuid] * 3, 
-    >>>    [convert_python_uuid_to_uuid_bytestring(uuid.uuid4()) for i in range(3)], 
-    >>>    [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
-    >>> )
-    >>> table = pa.Table.from_pydict(dict(zip(schema.names, rows)), schema=schema)
-    """
-    return pa.schema(
-        [
-            pa.field('recording', pa.binary(16), 
-                     nullable=False,
-                     metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
-            pa.field('id', pa.binary(16), 
-                     nullable=False,
-                     metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
-            pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
-                     nullable=False,
-                     metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}),
-        ]
-    )
+# https://github.com/beacon-biosignals/Onda.jl/blob/main/src/annotations.jl
+# cf. examples/generate_data.py
+ONDA_ANNOTATIONS_SCHEMA = pa.schema(
+    [
+        pa.field(
+            'recording', 
+            pa.binary(16), 
+            nullable=False, 
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field(
+            'id', 
+            pa.binary(16), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field(
+            'span',
+            pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
+        ),
+    ]
+)

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -69,10 +69,13 @@ def get_onda_annotations_schema():
     return pa.schema(
         [
             pa.field('recording', pa.binary(16), 
+                     nullable=False,
                      metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
             pa.field('id', pa.binary(16), 
+                     nullable=False,
                      metadata={"ARROW:extension:name": "JuliaLang.UUID"}),
             pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+                     nullable=False,
                      metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}),
         ]
     )

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -54,14 +54,14 @@ def get_onda_annotations_schema():
     Examples
     --------
     >>> from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtuple
-    >>> from pyonda.utils.processing import convert_python_uuid
+    >>> from pyonda.utils.processing import convert_python_uuid_to_uuid_bytestring
     >>> import pyarrow as pa
     >>> import uuid
     >>> schema = get_onda_annotations_schema()
-    >>> record_uuid = convert_python_uuid(uuid.uuid4())
+    >>> record_uuid = convert_python_uuid_to_uuid_bytestring(uuid.uuid4())
     >>> rows = (
     >>>    [record_uuid] * 3, 
-    >>>    [convert_python_uuid(uuid.uuid4()) for i in range(3)], 
+    >>>    [convert_python_uuid_to_uuid_bytestring(uuid.uuid4()) for i in range(3)], 
     >>>    [timespan_namedtuple(start=int(n*30*(1e9)), stop=int((n+1)*30*(1e9))) for n in range(3)]
     >>> )
     >>> table = pa.Table.from_pydict(dict(zip(schema.names, rows)), schema=schema)

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -45,23 +45,68 @@ def timespan_namedtuple(start, stop):
 # cf. examples/generate_data.py
 ONDA_ANNOTATIONS_SCHEMA = pa.schema(
     [
-        pa.field(
-            'recording', 
-            pa.binary(16), 
+        pa.field('recording', pa.binary(16), 
             nullable=False, 
             metadata={"ARROW:extension:name": "JuliaLang.UUID"}
         ),
-        pa.field(
-            'id', 
-            pa.binary(16), 
+        pa.field('id', pa.binary(16), 
             nullable=False,
             metadata={"ARROW:extension:name": "JuliaLang.UUID"}
         ),
-        pa.field(
-            'span',
-            pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+        pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
             nullable=False,
             metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
         ),
+    ],
+    metadata = {
+        "legolas_schema_qualified" : "clean-sleep.signal@1>datastore.signal@1>onda.signal@2>onda.samples-info@2"
+    }
+)
+
+# https://github.com/beacon-biosignals/Onda.jl/blob/main/src/signals.jl
+ONDA_SIGNALS_SCHEMA = pa.schema(
+    [
+        pa.field('recording', pa.binary(16), 
+            nullable=False, 
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('id', pa.binary(16), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('file_path', pa.string(), 
+            nullable=False
+        ),
+        pa.field('file_format', pa.string(), 
+            nullable=False
+        ),
+        pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
+        ),
+        pa.field('sensor_type', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sensor_label', pa.string(), 
+            nullable=False
+        ),
+        pa.field('channels', pa.list_(pa.string()), 
+            nullable=False
+        ),
+        pa.field('sample_unit', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sample_resolution_in_unit', pa.float64(), 
+            nullable=False
+        ),
+        pa.field('sample_offset_in_unit', pa.float64(), 
+            nullable=False
+        ),
+        pa.field('sample_type', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sample_rate', pa.float64(), 
+            nullable=False
+        )       
     ]
 )

--- a/src/pyonda/utils/schemas.py
+++ b/src/pyonda/utils/schemas.py
@@ -28,11 +28,11 @@ def timespan_namedtuple(start, stop):
     >>> ts.start
     1000000000.0
     """
-    if stop <= start:
-        raise ValueError('start should be < stop')
-
     if not isinstance(stop, int) or not isinstance(start, int):
         raise ValueError('start and stop should be integers (nanosecond values)')
+
+    if stop <= start:
+        raise ValueError('start should be < stop')
 
     if start != 0 and start < 1e9:
         warnings.warn('You have 0 < start < 1s, check that you put the value in nanoseconds')

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,6 @@
+import numpy as np
 import pytest
 import os
-import pandas as pd
-import ast
-import uuid
 import boto3 
 from pathlib import Path
 from moto import mock_s3
@@ -15,30 +13,6 @@ def lpcm_zst_file_path():
 @pytest.fixture
 def signal_arrow_table_path():
     return Path(os.path.abspath(__file__)).parent / "data/test.onda.signal.arrow"
-
-
-def assert_signal_arrow_dataframes_equal(df_processed):
-    df_expected = pd.read_csv(Path(os.path.abspath(__file__)).parent / "data/test.onda.signal_processed.csv")
-    df_expected['channels'] = df_expected['channels'].map(ast.literal_eval)
-    df_expected['recording'] = df_expected['recording'].map(uuid.UUID)
-    df_expected['span']= df_expected['span'].map(ast.literal_eval)
-
-    for df in [df_processed, df_expected]:
-        df['start_span'] = df['span'].map(lambda x : int(x['start']))
-        df['stop_span'] = df['span'].map(lambda x : int(x['stop']))
-        df.drop(['span'], axis=1, inplace=True)
-
-    pd.testing.assert_frame_equal(df, df_expected)
-
-
-@pytest.fixture(scope="function")
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
 
 
 @pytest.fixture
@@ -59,6 +33,28 @@ def lpcm_file_s3_url():
 @pytest.fixture
 def lpcm_zst_file_s3_url():
     return "s3://mock-bucket/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_ecg.lpcm.zst"
+
+
+@pytest.fixture
+def expected_eeg_data():
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
+    return expected_data
+    
+
+@pytest.fixture
+def expected_ecg_data():
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_ecg.npy")
+    return expected_data
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_load_arrow.py
+++ b/tests/test_load_arrow.py
@@ -7,15 +7,16 @@ from pyonda.load_arrow import (
     load_table_from_arrow_file, 
     load_table_from_arrow_file_in_s3
 )
+from tests.utils import assert_signal_arrow_dataframes_equal
 
 from tests.fixtures import (
-    aws_credentials,
-    signal_arrow_table_path,
-    lpcm_file_path,
+    aws_credentials, 
+    signal_arrow_table_path, 
+    lpcm_file_path, 
     lpcm_zst_file_path,
     s3,
-    signal_arrow_table_s3_url,
-    assert_signal_arrow_dataframes_equal
+
+    signal_arrow_table_s3_url
 )
 
 

--- a/tests/test_load_lpcm.py
+++ b/tests/test_load_lpcm.py
@@ -1,74 +1,57 @@
 import os
 import io
+import pytest
 import numpy as np
 from pathlib import Path
 
-from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+from pyonda.load_arrow import load_table_from_arrow_file
 from pyonda.load_lpcm import (
     load_array_from_lpcm_file_buffer,
     load_array_from_lpcm_file,
-    load_array_from_lpcm_zst_file,
-    load_array_from_lpcm_file_in_s3,
-    load_array_from_lpcm_zst_file_in_s3
+    load_array_from_lpcm_file_in_s3
 )
 
 from tests.fixtures import (
-    aws_credentials,
-    signal_arrow_table_path,
-    lpcm_file_path,
+    aws_credentials, 
+    signal_arrow_table_path, 
+    lpcm_file_path, 
     lpcm_zst_file_path,
     s3,
-    signal_arrow_table_s3_url,
+
     lpcm_file_s3_url,
-    lpcm_zst_file_s3_url
+    expected_eeg_data
 )
 
 
-def test_load_array_from_lpcm_file_buffer(lpcm_file_path, signal_arrow_table_path):
+@pytest.fixture
+def ref_series(signal_arrow_table_path, lpcm_file_path):
     df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
     series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
-    
+    return series
+
+
+@pytest.fixture
+def sample_type(ref_series):
+    return np.dtype(ref_series['sample_type'])
+
+
+@pytest.fixture
+def n_channels(ref_series):
+    return len(ref_series['channels'])
+
+
+def test_load_array_from_lpcm_file_buffer(lpcm_file_path, sample_type, n_channels, expected_eeg_data):    
     with open(lpcm_file_path, "rb") as fh:
         buffer = io.BytesIO(fh.read())
-    data = load_array_from_lpcm_file_buffer(buffer, np.dtype(series['sample_type']), len(series['channels']))
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
-
-    assert np.array_equal(data, expected_data)
+    data = load_array_from_lpcm_file_buffer(buffer, sample_type, n_channels)
+    assert np.array_equal(data, expected_eeg_data)
 
 
-def test_load_array_from_lpcm_file(lpcm_file_path, signal_arrow_table_path):
-    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
-    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
-
-    data = load_array_from_lpcm_file(lpcm_file_path, np.dtype(series['sample_type']), len(series['channels']))
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
-
-    assert np.array_equal(data, expected_data)
+def test_load_array_from_lpcm_file(lpcm_file_path, sample_type, n_channels, expected_eeg_data):
+    data = load_array_from_lpcm_file(lpcm_file_path, sample_type, n_channels)
+    assert np.array_equal(data, expected_eeg_data)
 
 
-def test_load_array_from_lpcm_zst_file(lpcm_zst_file_path, signal_arrow_table_path):
-    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
-    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_zst_file_path).stem)].squeeze()
-
-    data = load_array_from_lpcm_zst_file(lpcm_zst_file_path, np.dtype(series['sample_type']), len(series['channels']))
-
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_ecg.npy")
-    assert np.array_equal(data, expected_data)
-
-
-def test_load_array_from_lpcm_file_in_s3(s3, signal_arrow_table_s3_url, lpcm_file_s3_url):
-    df = load_table_from_arrow_file_in_s3(signal_arrow_table_s3_url, processed_pandas=True)
-    url_stem = Path(lpcm_file_s3_url).stem
-    series = df[df['file_path'].map(lambda x : Path(x).stem == url_stem)].squeeze()
-    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, np.dtype(series['sample_type']), len(series['channels']))
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
-    assert np.array_equal(data, expected_data)
-
-
-def test_load_array_from_lpcm_zst_file_in_s3(s3, signal_arrow_table_s3_url, lpcm_zst_file_s3_url):
-    df = load_table_from_arrow_file_in_s3(signal_arrow_table_s3_url, processed_pandas=True)
-    url_stem = Path(lpcm_zst_file_s3_url).stem
-    series = df[df['file_path'].map(lambda x : Path(x).stem == url_stem)].squeeze()
-    data = load_array_from_lpcm_zst_file_in_s3(lpcm_zst_file_s3_url,np.dtype(series['sample_type']), len(series['channels']))
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{Path(url_stem).stem}.npy")
-    assert np.array_equal(data, expected_data)
+def test_load_array_from_lpcm_file_in_s3(s3, lpcm_file_s3_url, sample_type, n_channels, expected_eeg_data):
+    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, sample_type, n_channels)
+    assert np.array_equal(data, expected_eeg_data)

--- a/tests/test_load_lpcm_zst.py
+++ b/tests/test_load_lpcm_zst.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+import numpy as np
+from pathlib import Path
+
+from pyonda.load_arrow import load_table_from_arrow_file
+from pyonda.load_lpcm import (
+    load_array_from_lpcm_zst_file,
+    load_array_from_lpcm_zst_file_in_s3
+)
+
+from tests.fixtures import (
+    aws_credentials, 
+    signal_arrow_table_path, 
+    lpcm_file_path, 
+    lpcm_zst_file_path,
+    s3,
+
+    lpcm_zst_file_s3_url,
+    expected_ecg_data
+)
+
+
+@pytest.fixture
+def ref_series(signal_arrow_table_path, lpcm_zst_file_path):
+    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
+    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_zst_file_path).stem)].squeeze()
+    return series
+
+
+@pytest.fixture
+def sample_type(ref_series):
+    return np.dtype(ref_series['sample_type'])
+
+
+@pytest.fixture
+def n_channels(ref_series):
+    return len(ref_series['channels'])
+
+
+def test_load_array_from_lpcm_zst_file(lpcm_zst_file_path, sample_type, n_channels, expected_ecg_data):
+    data = load_array_from_lpcm_zst_file(lpcm_zst_file_path, sample_type, n_channels)
+    assert np.array_equal(data, expected_ecg_data)
+
+
+def test_load_array_from_lpcm_zst_file_in_s3(s3, lpcm_zst_file_s3_url, sample_type, n_channels, expected_ecg_data):
+    data = load_array_from_lpcm_zst_file_in_s3(lpcm_zst_file_s3_url, sample_type, n_channels)
+    assert np.array_equal(data, expected_ecg_data)

--- a/tests/test_save_arrow.py
+++ b/tests/test_save_arrow.py
@@ -4,15 +4,14 @@ from pyonda.save_arrow import (
     save_table_to_s3
 )
 from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+from tests.utils import assert_signal_arrow_dataframes_equal
 
 from tests.fixtures import (
-    aws_credentials,
-    signal_arrow_table_path,
-    lpcm_file_path,
+    aws_credentials, 
+    signal_arrow_table_path, 
+    lpcm_file_path, 
     lpcm_zst_file_path,
-    s3,
-    signal_arrow_table_s3_url,
-    assert_signal_arrow_dataframes_equal
+    s3
 )
 
 

--- a/tests/test_save_arrow.py
+++ b/tests/test_save_arrow.py
@@ -1,3 +1,4 @@
+import pytest
 from pyonda.save_arrow import (
     save_table_to_arrow_file, 
     save_table_to_s3
@@ -15,15 +16,18 @@ from tests.fixtures import (
 )
 
 
-def test_save_table_to_arrow_file(signal_arrow_table_path, tmpdir):
-    ref_table = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=False)
-    save_table_to_arrow_file(tmpdir / "test_table.arrow", ref_table, ref_table.schema)
+@pytest.fixture
+def ref_table(signal_arrow_table_path):
+    return load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=False)
+
+
+def test_save_table_to_arrow_file(ref_table, tmpdir):
+    save_table_to_arrow_file(ref_table, ref_table.schema, tmpdir / "test_table.arrow")
     saved_table = load_table_from_arrow_file(tmpdir / "test_table.arrow", processed_pandas=False)
     assert saved_table == ref_table
 
     
-def test_save_table_to_s3(signal_arrow_table_path, s3):
-    ref_table = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=False)
+def test_save_table_to_s3(ref_table, s3):
     save_table_to_s3(ref_table, ref_table.schema, "mock-bucket", "test_table.arrow")
     saved_table = load_table_from_arrow_file_in_s3("s3://mock-bucket/test_table.arrow", processed_pandas=False)
     assert saved_table == ref_table

--- a/tests/test_save_arrow.py
+++ b/tests/test_save_arrow.py
@@ -1,0 +1,29 @@
+from pyonda.save_arrow import (
+    save_table_to_arrow_file, 
+    save_table_to_s3
+)
+from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+
+from tests.fixtures import (
+    aws_credentials,
+    signal_arrow_table_path,
+    lpcm_file_path,
+    lpcm_zst_file_path,
+    s3,
+    signal_arrow_table_s3_url,
+    assert_signal_arrow_dataframes_equal
+)
+
+
+def test_save_table_to_arrow_file(signal_arrow_table_path, tmpdir):
+    ref_table = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=False)
+    save_table_to_arrow_file(tmpdir / "test_table.arrow", ref_table, ref_table.schema)
+    saved_table = load_table_from_arrow_file(tmpdir / "test_table.arrow", processed_pandas=False)
+    assert saved_table == ref_table
+
+    
+def test_save_table_to_s3(signal_arrow_table_path, s3):
+    ref_table = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=False)
+    save_table_to_s3(ref_table, ref_table.schema, "mock-bucket", "test_table.arrow")
+    saved_table = load_table_from_arrow_file_in_s3("s3://mock-bucket/test_table.arrow", processed_pandas=False)
+    assert saved_table == ref_table

--- a/tests/test_save_lpcm.py
+++ b/tests/test_save_lpcm.py
@@ -1,10 +1,8 @@
 import pytest
 import numpy as np
-import os
 from pathlib import Path
 
-from pyonda.utils.decompression import decompress_zstandard_file_to_folder
-from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+from pyonda.load_arrow import load_table_from_arrow_file
 from pyonda.load_lpcm import (
     load_array_from_lpcm_file, 
     load_array_from_lpcm_file_in_s3, 
@@ -19,65 +17,51 @@ from pyonda.save_lpcm import (
 )
 
 from tests.fixtures import (
-    aws_credentials,
-    signal_arrow_table_path,
-    lpcm_file_path,
+   aws_credentials, 
+    signal_arrow_table_path, 
+    lpcm_file_path, 
     lpcm_zst_file_path,
     s3,
-    signal_arrow_table_s3_url,
-    assert_signal_arrow_dataframes_equal,
-    lpcm_file_s3_url
+    
+    expected_eeg_data
 )
 
+@pytest.fixture
+def ref_series(signal_arrow_table_path, lpcm_file_path):
+    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
+    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
+    return series
+
 
 @pytest.fixture
-def signal_table(signal_arrow_table_path):
-    return load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
+def sample_type(ref_series):
+    return np.dtype(ref_series['sample_type'])
 
 
 @pytest.fixture
-def load_params(signal_table, lpcm_file_path):
-    series = signal_table[signal_table['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
-    return np.dtype(series['sample_type']), len(series['channels'])
+def n_channels(ref_series):
+    return len(ref_series['channels'])
 
 
-def test_save_array_to_lpcm_file(load_params, lpcm_file_path, tmpdir):
-    dtype, n_channels = load_params
-    ref_array = load_array_from_lpcm_file(lpcm_file_path, dtype, n_channels)
-    save_array_to_lpcm_file(ref_array, tmpdir / "test_array.lpcm")
-
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
-    saved_data = load_array_from_lpcm_file(tmpdir / "test_array.lpcm", dtype, n_channels, "C")
-    assert np.array_equal(saved_data, expected_data)
+def test_save_array_to_lpcm_file(sample_type, n_channels, expected_eeg_data, tmpdir):
+    save_array_to_lpcm_file(expected_eeg_data, tmpdir / "test_array.lpcm")
+    saved_data = load_array_from_lpcm_file(tmpdir / "test_array.lpcm", sample_type, n_channels, "C")
+    assert np.array_equal(saved_data, expected_eeg_data)
 
 
-def test_save_array_to_lpcm_zst_file(load_params, lpcm_file_path, tmpdir):
-    dtype, n_channels = load_params
-    ref_array = load_array_from_lpcm_file(lpcm_file_path, dtype, n_channels)
-    save_array_to_lpcm_zst_file(ref_array, tmpdir / "test_array.lpcm.zst")
-
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
-    saved_data = load_array_from_lpcm_zst_file(tmpdir / "test_array.lpcm.zst", dtype, n_channels, "C")
-    assert np.array_equal(saved_data, expected_data)
+def test_save_array_to_lpcm_zst_file(sample_type, n_channels, expected_eeg_data, tmpdir):
+    save_array_to_lpcm_zst_file(expected_eeg_data, tmpdir / "test_array.lpcm.zst")
+    saved_data = load_array_from_lpcm_zst_file(tmpdir / "test_array.lpcm.zst", sample_type, n_channels, "C")
+    assert np.array_equal(saved_data, expected_eeg_data)
 
     
-def test_save_table_to_s3(load_params, lpcm_file_s3_url, s3):
-    dtype, n_channels = load_params
-    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, dtype, n_channels)
-    save_array_to_lpcm_file_in_s3(data, "mock-bucket", "test_array.lpcm")
-
-    url_stem = Path(lpcm_file_s3_url).stem
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
-    saved_data = load_array_from_lpcm_file_in_s3("s3://mock-bucket/test_array.lpcm", dtype, n_channels, "C")
-    assert np.array_equal(saved_data, expected_data)
+def test_save_array_to_lpcm_file_in_s3(s3, sample_type, n_channels, expected_eeg_data):
+    save_array_to_lpcm_file_in_s3(expected_eeg_data, "mock-bucket", "test_array.lpcm")
+    saved_data = load_array_from_lpcm_file_in_s3("s3://mock-bucket/test_array.lpcm", sample_type, n_channels, "C")
+    assert np.array_equal(saved_data, expected_eeg_data)
 
 
-def test_save_table_to_s3_compression(load_params, lpcm_file_s3_url, s3):
-    dtype, n_channels = load_params
-    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, dtype, n_channels)
-    save_array_to_lpcm_zst_file_in_s3(data, "mock-bucket", "test_array.lpcm.zst")
-
-    url_stem = Path(lpcm_file_s3_url).stem
-    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
-    saved_data = load_array_from_lpcm_zst_file_in_s3("s3://mock-bucket/test_array.lpcm.zst", dtype, n_channels, "C")
-    assert np.array_equal(saved_data, expected_data)
+def test_save_array_to_lpcm_zst_file_in_s3(s3, sample_type, n_channels, expected_eeg_data):
+    save_array_to_lpcm_zst_file_in_s3(expected_eeg_data, "mock-bucket", "test_array.lpcm.zst")
+    saved_data = load_array_from_lpcm_zst_file_in_s3("s3://mock-bucket/test_array.lpcm.zst", sample_type, n_channels, "C")
+    assert np.array_equal(saved_data, expected_eeg_data)

--- a/tests/test_save_lpcm.py
+++ b/tests/test_save_lpcm.py
@@ -1,16 +1,22 @@
-import inspect
-import io
-import pyarrow as pa
-from pathlib import Path
+import pytest
 import numpy as np
 import os
+from pathlib import Path
+
+from pyonda.utils.decompression import decompress_zstandard_file_to_folder
+from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+from pyonda.load_lpcm import (
+    load_array_from_lpcm_file, 
+    load_array_from_lpcm_file_in_s3, 
+    load_array_from_lpcm_zst_file,
+    load_array_from_lpcm_zst_file_in_s3
+)
 from pyonda.save_lpcm import (
     save_array_to_lpcm_file, 
-    save_array_to_lpcm_file_in_s3
+    save_array_to_lpcm_file_in_s3,
+    save_array_to_lpcm_zst_file, 
+    save_array_to_lpcm_zst_file_in_s3
 )
-
-from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
-from pyonda.load_lpcm import load_array_from_lpcm_file, load_array_from_lpcm_file_in_s3
 
 from tests.fixtures import (
     aws_credentials,
@@ -24,25 +30,54 @@ from tests.fixtures import (
 )
 
 
-def test_save_array_to_lpcm_file(signal_arrow_table_path, lpcm_file_path, tmpdir):
-    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
-    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
-    ref_array = load_array_from_lpcm_file(lpcm_file_path, np.dtype(series['sample_type']), len(series['channels']))
+@pytest.fixture
+def signal_table(signal_arrow_table_path):
+    return load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
+
+
+@pytest.fixture
+def load_params(signal_table, lpcm_file_path):
+    series = signal_table[signal_table['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
+    return np.dtype(series['sample_type']), len(series['channels'])
+
+
+def test_save_array_to_lpcm_file(load_params, lpcm_file_path, tmpdir):
+    dtype, n_channels = load_params
+    ref_array = load_array_from_lpcm_file(lpcm_file_path, dtype, n_channels)
     save_array_to_lpcm_file(ref_array, tmpdir / "test_array.lpcm")
 
     expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
-    saved_data = load_array_from_lpcm_file(tmpdir / "test_array.lpcm", np.dtype(series['sample_type']), len(series['channels']), "C")
+    saved_data = load_array_from_lpcm_file(tmpdir / "test_array.lpcm", dtype, n_channels, "C")
+    assert np.array_equal(saved_data, expected_data)
+
+
+def test_save_array_to_lpcm_zst_file(load_params, lpcm_file_path, tmpdir):
+    dtype, n_channels = load_params
+    ref_array = load_array_from_lpcm_file(lpcm_file_path, dtype, n_channels)
+    save_array_to_lpcm_zst_file(ref_array, tmpdir / "test_array.lpcm.zst")
+
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
+    saved_data = load_array_from_lpcm_zst_file(tmpdir / "test_array.lpcm.zst", dtype, n_channels, "C")
     assert np.array_equal(saved_data, expected_data)
 
     
-def test_save_table_to_s3(signal_arrow_table_s3_url, lpcm_file_s3_url, s3):
-    df = load_table_from_arrow_file_in_s3(signal_arrow_table_s3_url, processed_pandas=True)
-    url_stem = Path(lpcm_file_s3_url).stem
-    series = df[df['file_path'].map(lambda x : Path(x).stem == url_stem)].squeeze()
-    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, np.dtype(series['sample_type']), len(series['channels']))
-
+def test_save_table_to_s3(load_params, lpcm_file_s3_url, s3):
+    dtype, n_channels = load_params
+    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, dtype, n_channels)
     save_array_to_lpcm_file_in_s3(data, "mock-bucket", "test_array.lpcm")
 
+    url_stem = Path(lpcm_file_s3_url).stem
     expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
-    saved_data = load_array_from_lpcm_file_in_s3("s3://mock-bucket/test_array.lpcm", np.dtype(series['sample_type']), len(series['channels']), "C")
+    saved_data = load_array_from_lpcm_file_in_s3("s3://mock-bucket/test_array.lpcm", dtype, n_channels, "C")
+    assert np.array_equal(saved_data, expected_data)
+
+
+def test_save_table_to_s3_compression(load_params, lpcm_file_s3_url, s3):
+    dtype, n_channels = load_params
+    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, dtype, n_channels)
+    save_array_to_lpcm_zst_file_in_s3(data, "mock-bucket", "test_array.lpcm.zst")
+
+    url_stem = Path(lpcm_file_s3_url).stem
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
+    saved_data = load_array_from_lpcm_zst_file_in_s3("s3://mock-bucket/test_array.lpcm.zst", dtype, n_channels, "C")
     assert np.array_equal(saved_data, expected_data)

--- a/tests/test_save_lpcm.py
+++ b/tests/test_save_lpcm.py
@@ -1,0 +1,48 @@
+import inspect
+import io
+import pyarrow as pa
+from pathlib import Path
+import numpy as np
+import os
+from pyonda.save_lpcm import (
+    save_array_to_lpcm_file, 
+    save_array_to_lpcm_file_in_s3
+)
+
+from pyonda.load_arrow import load_table_from_arrow_file, load_table_from_arrow_file_in_s3
+from pyonda.load_lpcm import load_array_from_lpcm_file, load_array_from_lpcm_file_in_s3
+
+from tests.fixtures import (
+    aws_credentials,
+    signal_arrow_table_path,
+    lpcm_file_path,
+    lpcm_zst_file_path,
+    s3,
+    signal_arrow_table_s3_url,
+    assert_signal_arrow_dataframes_equal,
+    lpcm_file_s3_url
+)
+
+
+def test_save_array_to_lpcm_file(signal_arrow_table_path, lpcm_file_path, tmpdir):
+    df = load_table_from_arrow_file(signal_arrow_table_path, processed_pandas=True)
+    series = df[df['file_path'].map(lambda x : Path(x).stem == Path(lpcm_file_path).stem)].squeeze()
+    ref_array = load_array_from_lpcm_file(lpcm_file_path, np.dtype(series['sample_type']), len(series['channels']))
+    save_array_to_lpcm_file(ref_array, tmpdir / "test_array.lpcm")
+
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / "data/176ecfcf-d4c7-49ba-adec-f338d0a0c01f_eeg.npy")
+    saved_data = load_array_from_lpcm_file(tmpdir / "test_array.lpcm", np.dtype(series['sample_type']), len(series['channels']), "C")
+    assert np.array_equal(saved_data, expected_data)
+
+    
+def test_save_table_to_s3(signal_arrow_table_s3_url, lpcm_file_s3_url, s3):
+    df = load_table_from_arrow_file_in_s3(signal_arrow_table_s3_url, processed_pandas=True)
+    url_stem = Path(lpcm_file_s3_url).stem
+    series = df[df['file_path'].map(lambda x : Path(x).stem == url_stem)].squeeze()
+    data = load_array_from_lpcm_file_in_s3(lpcm_file_s3_url, np.dtype(series['sample_type']), len(series['channels']))
+
+    save_array_to_lpcm_file_in_s3(data, "mock-bucket", "test_array.lpcm")
+
+    expected_data = np.load(Path(os.path.abspath(__file__)).parent / f"data/{url_stem}.npy")
+    saved_data = load_array_from_lpcm_file_in_s3("s3://mock-bucket/test_array.lpcm", np.dtype(series['sample_type']), len(series['channels']), "C")
+    assert np.array_equal(saved_data, expected_data)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+import ast
+import os
+import uuid
+from pathlib import Path
+
+
+def assert_signal_arrow_dataframes_equal(df_processed):
+    """Load data/test.onda.signal_processed.csv as df, add some preprocessings to ensure
+    both dataframes are preprocessed similarly and apply pandas.testing.assert_frame_equal 
+
+    Parameters
+    ----------
+    df_processed : pandas.DataFrame
+        input dataframe to be tested
+    """
+    df_expected = pd.read_csv(Path(os.path.abspath(__file__)).parent / "data/test.onda.signal_processed.csv")
+    df_expected['channels'] = df_expected['channels'].map(ast.literal_eval)
+    df_expected['recording'] = df_expected['recording'].map(uuid.UUID)
+    df_expected['span']= df_expected['span'].map(ast.literal_eval)
+
+    for df in [df_processed, df_expected]:
+        df['start_span'] = df['span'].map(lambda x : int(x['start']))
+        df['stop_span'] = df['span'].map(lambda x : int(x['stop']))
+        df.drop(['span'], axis=1, inplace=True)
+
+    pd.testing.assert_frame_equal(df, df_expected)

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -1,0 +1,28 @@
+import pytest
+import shutil
+import numpy as np
+
+from pathlib import Path
+
+from pyonda.utils.compression import compress_file_to_zst
+from pyonda.utils.decompression import decompress_zstandard_file_to_stream
+
+from tests.fixtures import lpcm_file_path
+
+
+def test_compress_file_to_zst(tmpdir, lpcm_file_path):
+
+    test_lpcm_file_path = Path(tmpdir) / Path(lpcm_file_path.name)
+    shutil.copyfile(lpcm_file_path, test_lpcm_file_path)
+    
+    output_file_path = Path(tmpdir) / f"{Path(lpcm_file_path.name)}.zst"
+    compress_file_to_zst(test_lpcm_file_path, tmpdir)
+    assert output_file_path.is_file()
+
+    file_buf = decompress_zstandard_file_to_stream(output_file_path)
+    decompressed_data = np.ndarray(buffer = file_buf.getbuffer(), dtype = np.int16, shape = (2, 77490), order='F')
+
+    reference_data = np.copy(np.memmap(test_lpcm_file_path, dtype = np.int16, shape = (2, 77490), order='F'))
+    assert np.array_equal(decompressed_data, reference_data)
+    shutil.rmtree(tmpdir)
+    

--- a/tests/utils/test_processing.py
+++ b/tests/utils/test_processing.py
@@ -2,20 +2,20 @@ import pytest
 import pyarrow as pa
 from pyonda.utils.processing import (
     arrow_to_processed_pandas, 
-    convert_julia_uuid,
-    convert_python_uuid,
+    convert_julia_uuid_bytestring_to_uuid,
+    convert_python_uuid_to_uuid_bytestring,
     check_if_schema_field_has_unsupported_binary_data
 )
 from tests.fixtures import signal_arrow_table_path, assert_signal_arrow_dataframes_equal
 
 
 def test_convert_julia_uuid():
-    assert convert_julia_uuid(None) is None, "None input should return a None output"
+    assert convert_julia_uuid_bytestring_to_uuid(None) is None, "None input should return a None output"
     # TODO how to test this
 
 
 def test_convert_python_uuid():
-    assert convert_python_uuid(None) is None, "None input should return a None output"
+    assert convert_python_uuid_to_uuid_bytestring(None) is None, "None input should return a None output"
     # TODO how to test this
 
     

--- a/tests/utils/test_processing.py
+++ b/tests/utils/test_processing.py
@@ -3,6 +3,7 @@ import pyarrow as pa
 from pyonda.utils.processing import (
     arrow_to_processed_pandas, 
     convert_julia_uuid,
+    convert_python_uuid,
     check_if_schema_field_has_unsupported_binary_data
 )
 from tests.fixtures import signal_arrow_table_path, assert_signal_arrow_dataframes_equal
@@ -10,6 +11,11 @@ from tests.fixtures import signal_arrow_table_path, assert_signal_arrow_datafram
 
 def test_convert_julia_uuid():
     assert convert_julia_uuid(None) is None, "None input should return a None output"
+    # TODO how to test this
+
+
+def test_convert_python_uuid():
+    assert convert_python_uuid(None) is None, "None input should return a None output"
     # TODO how to test this
 
     

--- a/tests/utils/test_processing.py
+++ b/tests/utils/test_processing.py
@@ -6,7 +6,8 @@ from pyonda.utils.processing import (
     convert_python_uuid_to_uuid_bytestring,
     check_if_schema_field_has_unsupported_binary_data
 )
-from tests.fixtures import signal_arrow_table_path, assert_signal_arrow_dataframes_equal
+from tests.utils import assert_signal_arrow_dataframes_equal
+from tests.fixtures import signal_arrow_table_path
 
 
 def test_convert_julia_uuid():

--- a/tests/utils/test_s3_upload.py
+++ b/tests/utils/test_s3_upload.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import pyarrow as pa
+import boto3
+
+from pyonda.utils.s3_upload import upload_file_to_s3
+
+from tests.fixtures import (
+    aws_credentials,
+    signal_arrow_table_path,
+    signal_arrow_table_s3_url,
+    lpcm_file_path, 
+    lpcm_zst_file_path,
+    s3
+)
+
+
+def test_upload_s3_file(s3, signal_arrow_table_s3_url, signal_arrow_table_path, tmpdir):
+    upload_file_to_s3(signal_arrow_table_path, "mock-bucket", "test-upload.onda.signal.arrow")
+
+    output_file_path = os.path.join(tmpdir, 'test.onda.signal.arrow')
+
+    client = boto3.client("s3")
+    client.download_file("mock-bucket", "test-upload.onda.signal.arrow", output_file_path)
+
+    reference_table = pa.ipc.open_file(pa.memory_map(str(signal_arrow_table_path), 'r')).read_all()
+    downloaded_table = pa.ipc.open_file(pa.memory_map(output_file_path, 'r')).read_all()
+    assert downloaded_table == reference_table, "Loaded arrow table is not as expected"
+    
+    shutil.rmtree(tmpdir)

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -1,0 +1,32 @@
+import pyarrow as pa
+import pytest
+from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtuple
+
+
+def test_timespan_namedtuple():
+    TimeSpan = timespan_namedtuple(start = 10*1e9, stop = 20*1e9)
+    assert TimeSpan._fields == ('start', 'stop')
+
+
+def test_timespan_namedtuple_stop_smaller_than_start():
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = 20*1e9, stop = 10*1e9)
+
+
+def test_timespan_namedtuple_bad_types():
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = "nope", stop = 10*1e9)
+
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = 20*1e9, stop = "nope")
+
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = "nope", stop = "nope")
+
+
+def test_get_onda_annotations_schema():
+    schema = get_onda_annotations_schema()
+    assert schema.names == ['recording', 'id', 'span']
+    assert get_onda_annotations_schema().field('recording').type.equals(pa.binary(16))
+    assert get_onda_annotations_schema().field('id').type.equals(pa.binary(16))
+    assert get_onda_annotations_schema().field('span').type.equals(pa.struct([('start', pa.int64()), ('stop', pa.int64())]))

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -1,6 +1,6 @@
 import pyarrow as pa
 import pytest
-from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, timespan_namedtuple
+from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, ONDA_SIGNALS_SCHEMA, timespan_namedtuple
 
 
 def test_timespan_namedtuple():
@@ -32,20 +32,69 @@ def test_timespan_namedtuple_bad_types():
         timespan_namedtuple(start = int(10*1e9), stop = 30*1e9)
 
 
-def test_get_onda_annotations_schema():
-    assert ONDA_ANNOTATIONS_SCHEMA.names == ['recording', 'id', 'span']
+def test_onda_annotations_schema():
+    assert ONDA_ANNOTATIONS_SCHEMA == pa.schema(
+    [
+        pa.field('recording', pa.binary(16), 
+            nullable=False, 
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('id', pa.binary(16), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
+        ),
+    ]
+)
 
-    recording_field = ONDA_ANNOTATIONS_SCHEMA.field('recording')
-    assert recording_field.type.equals(pa.binary(16))
-    assert not recording_field.nullable
-    assert recording_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
 
-    id_field = ONDA_ANNOTATIONS_SCHEMA.field('recording')
-    assert id_field.type.equals(pa.binary(16))
-    assert not id_field.nullable
-    assert id_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
-    
-    span_field = ONDA_ANNOTATIONS_SCHEMA.field('span')
-    assert span_field.type.equals(pa.struct([('start', pa.int64()), ('stop', pa.int64())]))
-    assert not span_field.nullable
-    assert span_field.metadata == {b"ARROW:extension:name": b"JuliaLang.TimeSpan"}
+def test_onda_signals_schema():
+    assert ONDA_SIGNALS_SCHEMA == pa.schema(
+    [
+        pa.field('recording', pa.binary(16), 
+            nullable=False, 
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('id', pa.binary(16), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.UUID"}
+        ),
+        pa.field('file_path', pa.string(), 
+            nullable=False
+        ),
+        pa.field('file_format', pa.string(), 
+            nullable=False
+        ),
+        pa.field('span', pa.struct([('start', pa.int64()), ('stop', pa.int64())]), 
+            nullable=False,
+            metadata={"ARROW:extension:name": "JuliaLang.TimeSpan"}
+        ),
+        pa.field('sensor_type', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sensor_label', pa.string(), 
+            nullable=False
+        ),
+        pa.field('channels', pa.list_(pa.string()), 
+            nullable=False
+        ),
+        pa.field('sample_unit', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sample_resolution_in_unit', pa.float64(), 
+            nullable=False
+        ),
+        pa.field('sample_offset_in_unit', pa.float64(), 
+            nullable=False
+        ),
+        pa.field('sample_type', pa.string(), 
+            nullable=False
+        ),
+        pa.field('sample_rate', pa.float64(), 
+            nullable=False
+        )       
+    ]
+)

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -6,24 +6,30 @@ from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, timespan_namedtuple
 def test_timespan_namedtuple():
     TimeSpan = timespan_namedtuple(start = int(10*1e9), stop = int(20*1e9))
     assert TimeSpan._fields == ('start', 'stop')
-    assert TimeSpan.start == 10*1e9
-    assert TimeSpan.stop == 20*1e9
+    assert TimeSpan.start == int(10*1e9)
+    assert TimeSpan.stop == int(20*1e9)
 
 
 def test_timespan_namedtuple_stop_smaller_than_start():
     with pytest.raises(ValueError):
-        timespan_namedtuple(start = 20*1e9, stop = 10*1e9)
+        timespan_namedtuple(start = int(20*1e9), stop = int(10*1e9))
 
 
 def test_timespan_namedtuple_bad_types():
     with pytest.raises(ValueError):
-        timespan_namedtuple(start = "nope", stop = 10*1e9)
+        timespan_namedtuple(start = "nope", stop = int(10*1e9))
 
     with pytest.raises(ValueError):
-        timespan_namedtuple(start = 20*1e9, stop = "nope")
+        timespan_namedtuple(start = int(20*1e9), stop = "nope")
 
     with pytest.raises(ValueError):
         timespan_namedtuple(start = "nope", stop = "nope")
+
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = 10*1e9, stop = int(30*1e9))
+
+    with pytest.raises(ValueError):
+        timespan_namedtuple(start = int(10*1e9), stop = 30*1e9)
 
 
 def test_get_onda_annotations_schema():

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -1,6 +1,6 @@
 import pyarrow as pa
 import pytest
-from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtuple
+from pyonda.utils.schemas import ONDA_ANNOTATIONS_SCHEMA, timespan_namedtuple
 
 
 def test_timespan_namedtuple():
@@ -27,20 +27,19 @@ def test_timespan_namedtuple_bad_types():
 
 
 def test_get_onda_annotations_schema():
-    schema = get_onda_annotations_schema()
-    assert schema.names == ['recording', 'id', 'span']
+    assert ONDA_ANNOTATIONS_SCHEMA.names == ['recording', 'id', 'span']
 
-    recording_field = get_onda_annotations_schema().field('recording')
+    recording_field = ONDA_ANNOTATIONS_SCHEMA.field('recording')
     assert recording_field.type.equals(pa.binary(16))
     assert not recording_field.nullable
     assert recording_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
 
-    id_field = get_onda_annotations_schema().field('recording')
+    id_field = ONDA_ANNOTATIONS_SCHEMA.field('recording')
     assert id_field.type.equals(pa.binary(16))
     assert not id_field.nullable
     assert id_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
     
-    span_field = get_onda_annotations_schema().field('span')
+    span_field = ONDA_ANNOTATIONS_SCHEMA.field('span')
     assert span_field.type.equals(pa.struct([('start', pa.int64()), ('stop', pa.int64())]))
     assert not span_field.nullable
     assert span_field.metadata == {b"ARROW:extension:name": b"JuliaLang.TimeSpan"}

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -29,6 +29,18 @@ def test_timespan_namedtuple_bad_types():
 def test_get_onda_annotations_schema():
     schema = get_onda_annotations_schema()
     assert schema.names == ['recording', 'id', 'span']
-    assert get_onda_annotations_schema().field('recording').type.equals(pa.binary(16))
-    assert get_onda_annotations_schema().field('id').type.equals(pa.binary(16))
-    assert get_onda_annotations_schema().field('span').type.equals(pa.struct([('start', pa.int64()), ('stop', pa.int64())]))
+
+    recording_field = get_onda_annotations_schema().field('recording')
+    assert recording_field.type.equals(pa.binary(16))
+    assert not recording_field.nullable
+    assert recording_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
+
+    id_field = get_onda_annotations_schema().field('recording')
+    assert id_field.type.equals(pa.binary(16))
+    assert not id_field.nullable
+    assert id_field.metadata == {b"ARROW:extension:name": b"JuliaLang.UUID"}
+    
+    span_field = get_onda_annotations_schema().field('span')
+    assert span_field.type.equals(pa.struct([('start', pa.int64()), ('stop', pa.int64())]))
+    assert not span_field.nullable
+    assert span_field.metadata == {b"ARROW:extension:name": b"JuliaLang.TimeSpan"}

--- a/tests/utils/test_schemas.py
+++ b/tests/utils/test_schemas.py
@@ -4,8 +4,10 @@ from pyonda.utils.schemas import get_onda_annotations_schema, timespan_namedtupl
 
 
 def test_timespan_namedtuple():
-    TimeSpan = timespan_namedtuple(start = 10*1e9, stop = 20*1e9)
+    TimeSpan = timespan_namedtuple(start = int(10*1e9), stop = int(20*1e9))
     assert TimeSpan._fields == ('start', 'stop')
+    assert TimeSpan.start == 10*1e9
+    assert TimeSpan.stop == 20*1e9
 
 
 def test_timespan_namedtuple_stop_smaller_than_start():


### PR DESCRIPTION
Resolves #4 

### Utils
- Add function to reverse python uuid bytestring
- Add function to create Onda.annotation like schema
- Add function to create a TimeSpan like struct
- Add function to compress lpcm to lpcm zst

### Save functions
- Add function to save pyarrow tables in arrow format (local or s3)
- Add function to save numpy arrays in lpcm format, column major (local or s3)
- Add function to save numpy arrays in lpcm zst format, column major (local or s3)

### Scripts
- Add example script to generate and save data using all mentioned above


### Tests
- Add tests for all mentioned above

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205781728046802