### PR TITLE
Add boto3 client as argument to upload to/download from s3 functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyonda"
-version = "0.1.0"
+version = "0.2.0"
 description = 'Python tools to handle Onda formatted data'
 readme = "README.md"
 requires-python = ">=3.8, <3.10"

--- a/src/pyonda/load_arrow.py
+++ b/src/pyonda/load_arrow.py
@@ -3,6 +3,8 @@ import pyarrow as pa
 from pyonda.utils.s3_download import download_s3_fileobj
 from pyonda.utils.processing import arrow_to_processed_pandas
 
+from botocore.client import BaseClient
+
 
 def load_table_from_arrow_file_buffer(buffer, processed_pandas=True):
     """Load arrow table into pyarrow table or pandas dataframe with a processing step
@@ -43,7 +45,7 @@ def load_table_from_arrow_file(path_to_table, processed_pandas=True):
     return load_table_from_arrow_file_buffer(pa.memory_map(str(path_to_table), 'r'), processed_pandas)
 
 
-def load_table_from_arrow_file_in_s3(table_url,  processed_pandas=True):
+def load_table_from_arrow_file_in_s3(table_url,  processed_pandas=True, client:BaseClient=None):
     """Load arrow table from S3 into pyarrow table or pandas dataframe with a processing step
 
     Parameters
@@ -52,11 +54,13 @@ def load_table_from_arrow_file_in_s3(table_url,  processed_pandas=True):
         S3 URL to table
     processed_pandas : bool, optional
         if True apply arrow_to_processed_pandas to loaded table, by default True
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
     dataframe: pandas.DataFrame
         table contents loaded into a pandas DataFrame
     """
-    table_buf = download_s3_fileobj(table_url)
+    table_buf = download_s3_fileobj(table_url, client)
     return load_table_from_arrow_file_buffer(table_buf, processed_pandas)

--- a/src/pyonda/load_lpcm.py
+++ b/src/pyonda/load_lpcm.py
@@ -3,6 +3,7 @@ import io
 
 from pyonda.utils.s3_download import download_s3_fileobj
 from pyonda.utils.decompression import decompress_zstandard_file_to_stream, decompress_zstandard_stream_to_stream
+from botocore.client import BaseClient
 
 
 def load_array_from_lpcm_file_buffer(buffer, dtype, n_channels, order="F"):
@@ -56,7 +57,7 @@ def load_array_from_lpcm_file(path_to_file, dtype, n_channels, order="F"):
     return load_array_from_lpcm_file_buffer(buffer, dtype, n_channels, order)
 
 
-def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F"):
+def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F", client:BaseClient=None):
     """Load lpcm file content from S3 as a numpy array with correct data type and shape
 
     Parameters
@@ -69,13 +70,15 @@ def load_array_from_lpcm_file_in_s3(file_url, dtype, n_channels, order="F"):
         number of channels used to reshape data
     order : str
         C or F, use F to read files from Julia, use C to save files for Julia
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
     data: ndarray
         numpy array with lpcm file content 
     """
-    file_buf = download_s3_fileobj(file_url)
+    file_buf = download_s3_fileobj(file_url, client)
     return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)
 
 
@@ -102,7 +105,7 @@ def load_array_from_lpcm_zst_file(path_to_file, dtype, n_channels, order="F"):
     return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)
 
 
-def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels, order="F"):
+def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels, order="F", client:BaseClient=None):
     """Decompress lpcm zst from s3 and load file content as a numpy array with correct data type and shape
 
     Parameters
@@ -115,12 +118,14 @@ def load_array_from_lpcm_zst_file_in_s3(file_url, dtype, n_channels, order="F"):
         number of channels used to reshape data
     order : str
         C or F, use F to read files from Julia, use C to save files for Julia
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
     data: ndarray
         numpy array with lpcm file content 
     """
-    file_buf = download_s3_fileobj(file_url)
+    file_buf = download_s3_fileobj(file_url, client)
     file_buf = decompress_zstandard_stream_to_stream(file_buf)
     return load_array_from_lpcm_file_buffer(file_buf, dtype, n_channels, order)

--- a/src/pyonda/save_arrow.py
+++ b/src/pyonda/save_arrow.py
@@ -3,6 +3,7 @@ import tempfile
 
 from pyonda.utils.s3_upload import upload_file_to_s3
 from pathlib import Path
+from botocore.client import BaseClient
 
 
 def save_table_to_arrow_file(table, schema, output_path):
@@ -22,7 +23,7 @@ def save_table_to_arrow_file(table, schema, output_path):
             writer.write(table)
 
 
-def save_table_to_s3(table, schema, bucket, key):
+def save_table_to_s3(table, schema, bucket, key, client:BaseClient=None):
     """Save table in a temp dir and upload it to s3
 
     Parameters
@@ -35,6 +36,8 @@ def save_table_to_s3(table, schema, bucket, key):
         destination bucket name
     key : str
         destination file key
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
@@ -45,6 +48,6 @@ def save_table_to_s3(table, schema, bucket, key):
     temp_file_path = Path(temp_dir.name) / "table_to_upload.arrow"
     try:
         save_table_to_arrow_file(table, schema, temp_file_path)
-        upload_file_to_s3(temp_file_path, bucket, key)
+        upload_file_to_s3(temp_file_path, bucket, key, client)
     finally:
         temp_dir.cleanup()

--- a/src/pyonda/save_lpcm.py
+++ b/src/pyonda/save_lpcm.py
@@ -1,9 +1,9 @@
 import numpy as np
 import tempfile
-import os
 from pathlib import Path
 from pyonda.utils.s3_upload import upload_file_to_s3
 from pyonda.utils.compression import compress_file_to_zst
+from botocore.client import BaseClient
 
 
 def save_array_to_lpcm_file(array, output_path):
@@ -54,7 +54,7 @@ def save_array_to_lpcm_zst_file(array, output_path):
         temp_dir.cleanup()
 
 
-def save_array_to_lpcm_file_in_s3(array, bucket, key):
+def save_array_to_lpcm_file_in_s3(array, bucket, key, client:BaseClient=None):
     """Save a numpy array in a temp dir as a .lpcm and upload it to s3
 
     Parameters
@@ -65,6 +65,8 @@ def save_array_to_lpcm_file_in_s3(array, bucket, key):
         destination bucket name
     key : str
         destination file key
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
@@ -75,12 +77,12 @@ def save_array_to_lpcm_file_in_s3(array, bucket, key):
     temp_file_path = Path(temp_dir.name) / "array_to_upload.lpcm"
     try:
         save_array_to_lpcm_file(array, temp_file_path)
-        upload_status = upload_file_to_s3(temp_file_path, bucket, key)
+        upload_file_to_s3(temp_file_path, bucket, key, client)
     finally:
         temp_dir.cleanup()
 
 
-def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
+def save_array_to_lpcm_zst_file_in_s3(array, bucket, key, client:BaseClient=None):
     """Save a numpy array in a temp dir as a .lpcm and upload it to s3
 
     Parameters
@@ -93,6 +95,8 @@ def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
         destination file key
     compress : bool, default=False
         if true, compress file to .zst 
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
@@ -106,6 +110,6 @@ def save_array_to_lpcm_zst_file_in_s3(array, bucket, key):
         compress_file_to_zst(temp_file_path, Path(temp_dir.name))
 
         compressed_file_path = Path(temp_dir.name) / 'array_to_upload.lpcm.zst'
-        upload_file_to_s3(compressed_file_path, bucket, key)
+        upload_file_to_s3(compressed_file_path, bucket, key, client)
     finally:
         temp_dir.cleanup()

--- a/src/pyonda/utils/s3_download.py
+++ b/src/pyonda/utils/s3_download.py
@@ -1,5 +1,6 @@
 import io
 import boto3
+from botocore.client import BaseClient
 
 
 def path_is_an_s3_url(path):
@@ -44,7 +45,7 @@ def parse_s3_url(s3_url):
     return bucket, key, version
 
 
-def download_s3_file(s3_url, output_file_path):
+def download_s3_file(s3_url, output_file_path, client:BaseClient=None):
     """Given an object URL in S3, download an object from S3 to a file
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/download_file.html
 
@@ -54,8 +55,11 @@ def download_s3_file(s3_url, output_file_path):
         input S3 URL string 
     output_file_path : str or Path
         new path on local storage for downloaded object
+    client: BaseClient, default=None
+        boto3 client instance
     """
-    client = boto3.client("s3")
+    if client is None:
+        client = boto3.client("s3")
     bucket, key, version = parse_s3_url(s3_url)
     if version is not None:
         client.download_file(bucket, key, output_file_path, ExtraArgs={"VersionId": version})
@@ -63,7 +67,7 @@ def download_s3_file(s3_url, output_file_path):
         client.download_file(bucket, key, output_file_path)
 
 
-def download_s3_fileobj(s3_url):
+def download_s3_fileobj(s3_url, client:BaseClient=None):
     """Given an object URL in S3, download an object from S3 to a binary stream
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/download_fileobj.html
 
@@ -71,13 +75,16 @@ def download_s3_fileobj(s3_url):
     ----------
     s3_url : str or Path
         input S3 URL string
+    client: BaseClient, default=None
+        boto3 client instance
 
     Returns
     -------
     buf: BytesIO
         binary stream holding the downloaded object
     """
-    client = boto3.client("s3")
+    if client is None:
+        client = boto3.client("s3")
     bucket, key, version = parse_s3_url(s3_url)
     buf = io.BytesIO()
     if version is not None:

--- a/src/pyonda/utils/s3_upload.py
+++ b/src/pyonda/utils/s3_upload.py
@@ -1,7 +1,8 @@
 import boto3 
+from botocore.client import BaseClient
 
 
-def upload_file_to_s3(input_path, bucket, key):
+def upload_file_to_s3(input_path, bucket, key, client:BaseClient=None):
     """Upload a file to S3
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html
 
@@ -13,6 +14,10 @@ def upload_file_to_s3(input_path, bucket, key):
         destination bucket name
     key : str
         destination key
+    client: BaseClient, default=None
+        boto3 client instance
+
     """
-    client = boto3.client("s3")
-    _ = client.upload_file(str(input_path), bucket, key)
+    if client is None:
+        client = boto3.client("s3")
+    client.upload_file(str(input_path), bucket, key)


### PR DESCRIPTION
### Current Code
All download from s3 / upload to s3 functions instantiate a `boto3.client`. This is fine but can create a bottleneck if a process calls those functions a lot (e.g. download N files -> N client instances)

### New code
client is added as argument to all functions interacting with s3, allowing the user to instantiate a single client at the start of the process and provide it to all those functions (e.g. download N files -> single client instance)